### PR TITLE
Use weakmaps again now that bug 819131 was fixed in Firefox 20.

### DIFF
--- a/lib/requestNotifier.js
+++ b/lib/requestNotifier.js
@@ -29,10 +29,8 @@ let windowStats = new WeakMap();
 let windowSelection = new WeakMap();
 
 let setEntry, hasEntry, getEntry;
-if (false)
+if (Services.vc.compare(Utils.platformVersion, "20.0") >= 0)
 {
-  // This branch can be enabled again once both bug 673468 and bug 819131 are
-  // fixed and we can use weak maps
   setEntry = function(map, key, value) map.set(key, value);
   hasEntry = function(map, key) map.has(key);
   getEntry = function(map, key) map.get(key);


### PR DESCRIPTION
This also silences a warning for getUserData and setUserData added in bug 881252.

I notice this all of the time and it was reported on the forums at https://adblockplus.org/forum/viewtopic.php?f=11&t=15338&p=76393 and https://adblockplus.org/forum/viewtopic.php?f=11&t=15732&p=77212 (I don't have a forum account to point here).

The test suite seemed to have the same number of failures before and after this change. I didn't do manual testing because I didn't look at what the weak maps are used for. I mostly want to silence the warning.

This is a partial revert of 987f2b9.
